### PR TITLE
Support short trigger syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .serverless
 node_modules
+.vscode

--- a/__fixtures__/config.js
+++ b/__fixtures__/config.js
@@ -1,0 +1,131 @@
+const secretValueConfig = {
+    kind: "secret",
+    name: "access_id",
+    get: {
+        path: "prod/aws",
+        name: "access_key_id"
+    }
+};
+
+const noChangesetConfig = [
+    {
+        kind: "pipeline",
+        name: "build",
+
+        steps: [
+            {
+                name: "build",
+                image: "node:10.15.3",
+                commands: [
+                    "export TZ=Europe/Stockholm",
+                    "curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0",
+                    'export PATH="$HOME/.yarn/bin:$PATH"',
+                    "yarn install --ignore-optional --frozen-lockfile",
+                    "yarn build"
+                ]
+            }
+        ],
+
+        trigger: {
+            branch: ["master"],
+            event: ["push"]
+        }
+    },
+    secretValueConfig
+];
+
+const getPipelineChangesetConfig = changeset => [
+    {
+        kind: "pipeline",
+        name: "build",
+
+        steps: [
+            {
+                name: "build",
+                image: "node:10.15.3",
+                commands: [
+                    "export TZ=Europe/Stockholm",
+                    "curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0",
+                    'export PATH="$HOME/.yarn/bin:$PATH"',
+                    "yarn install --ignore-optional --frozen-lockfile",
+                    "yarn build"
+                ]
+            }
+        ],
+
+        trigger: {
+            changeset,
+            event: ["push"]
+        }
+    },
+    secretValueConfig
+];
+
+const stepsChangesetConfig = [
+    {
+        kind: "pipeline",
+        name: "build",
+
+        steps: [
+            {
+                name: "test",
+                image: "node:10.15.3",
+                commands: ["npm run test"],
+                when: {
+                    changeset: ["*.test.js"]
+                }
+            },
+            {
+                name: "build",
+                image: "node:10.15.3",
+                commands: ["npm run build"],
+                when: {
+                    changeset: ["*.js"]
+                }
+            }
+        ],
+
+        trigger: {
+            branch: ["master"],
+            event: ["push"]
+        }
+    }
+];
+
+const getConfigWithStepsChangeset = stepChangesetConfig => [
+    {
+        kind: "pipeline",
+        name: "build",
+
+        steps: [
+            {
+                name: "test",
+                image: "node:10.15.3",
+                commands: ["npm run test"],
+                when: {
+                    changeset: stepChangesetConfig
+                }
+            },
+            {
+                name: "build",
+                image: "node:10.15.3",
+                commands: ["npm run build"],
+                when: {
+                    changeset: stepChangesetConfig
+                }
+            }
+        ],
+
+        trigger: {
+            branch: ["master"],
+            event: ["push"]
+        }
+    }
+];
+
+module.exports = {
+    noChangesetConfig,
+    stepsChangesetConfig,
+    getPipelineChangesetConfig,
+    getConfigWithStepsChangeset
+};

--- a/__tests__/__snapshots__/changes.test.js.snap
+++ b/__tests__/__snapshots__/changes.test.js.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`changes getMatchingConfig should disable pipeline which changeset trigger does not match changed files 1`] = `
+"kind: pipeline
+name: build
+steps:
+  - name: build
+    image: node:10.15.3
+    commands:
+      - export TZ=Europe/Stockholm
+      - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0
+      - export PATH=\\"$HOME/.yarn/bin:$PATH\\"
+      - yarn install --ignore-optional --frozen-lockfile
+      - yarn build
+trigger:
+  event:
+    exclude:
+      - \\"*\\"
+
+---
+kind: secret
+name: access_id
+get:
+  path: prod/aws
+  name: access_key_id
+"
+`;
+
+exports[`changes getMatchingConfig should filter out steps which changeset trigger does not match the changes 1`] = `
+"kind: pipeline
+name: build
+steps:
+  - name: build
+    image: node:10.15.3
+    commands:
+      - npm run build
+    when:
+      changeset:
+        - \\"*.js\\"
+trigger:
+  branch:
+    - master
+  event:
+    - push
+"
+`;
+
+exports[`changes getMatchingConfig should replace pipelines where all steps are filtered out with noop config 1`] = `
+"kind: pipeline
+  name: default_0
+  trigger:
+    event:
+      exclude: [ \\"*\\" ]
+"
+`;
+
+exports[`changes getMatchingConfig should return config with no changes if event trigger does not match the drone event 1`] = `
+"kind: pipeline
+name: build
+steps:
+  - name: build
+    image: node:10.15.3
+    commands:
+      - export TZ=Europe/Stockholm
+      - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0
+      - export PATH=\\"$HOME/.yarn/bin:$PATH\\"
+      - yarn install --ignore-optional --frozen-lockfile
+      - yarn build
+trigger:
+  branch:
+    - master
+  event:
+    - push
+
+---
+kind: secret
+name: access_id
+get:
+  path: prod/aws
+  name: access_key_id
+"
+`;
+
+exports[`changes getMatchingConfig should return config with no changes if no changeset triggers are present 1`] = `
+"kind: pipeline
+name: build
+steps:
+  - name: build
+    image: node:10.15.3
+    commands:
+      - export TZ=Europe/Stockholm
+      - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0
+      - export PATH=\\"$HOME/.yarn/bin:$PATH\\"
+      - yarn install --ignore-optional --frozen-lockfile
+      - yarn build
+trigger:
+  branch:
+    - master
+  event:
+    - push
+
+---
+kind: secret
+name: access_id
+get:
+  path: prod/aws
+  name: access_key_id
+"
+`;

--- a/__tests__/changes.test.js
+++ b/__tests__/changes.test.js
@@ -81,4 +81,30 @@ describe("changes", () => {
             expect(result).toBe(trigger.include);
         });
     });
+
+    describe("isMatchingEvent", () => {
+        it("should return false if there are no include triggers in the triggerConfig", () => {
+            const changes = require("../changes");
+            const trigger = {};
+            const result = changes.isMatchingEvent(trigger, "push");
+
+            expect(result).toBe(false);
+        });
+
+        it("should return false if event does not match any of the include triggers", () => {
+            const changes = require("../changes");
+            const trigger = {include: ["push"]};
+            const result = changes.isMatchingEvent(trigger, "pull_request");
+
+            expect(result).toBe(false);
+        });
+
+        it("should return true if event matches some of the include triggers", () => {
+            const changes = require("../changes");
+            const trigger = {include: ["push"]};
+            const result = changes.isMatchingEvent(trigger, "push");
+
+            expect(result).toBe(true);
+        });
+    });
 });

--- a/__tests__/changes.test.js
+++ b/__tests__/changes.test.js
@@ -63,4 +63,22 @@ describe("changes", () => {
             expect(result).toBe(false);
         });
     });
+
+    describe("getIncludeTriggers", () => {
+        it("should return triggerConfig param if it is an array", () => {
+            const changes = require("../changes");
+            const trigger = [];
+            const result = changes.getIncludeTriggers(trigger);
+
+            expect(result).toBe(trigger);
+        });
+
+        it("should return triggerConfig's 'include' value if trigger is an object", () => {
+            const changes = require("../changes");
+            const trigger = {include: []};
+            const result = changes.getIncludeTriggers(trigger);
+
+            expect(result).toBe(trigger.include);
+        });
+    });
 });

--- a/__tests__/changes.test.js
+++ b/__tests__/changes.test.js
@@ -154,4 +154,31 @@ describe("changes", () => {
             expect(result).toBe(true);
         });
     });
+
+    describe("filterSteps", () => {
+        it("should return original steps if none of them have changeset triggers", () => {
+            const changes = require("../changes");
+            const steps = [{}, {}];
+            const changedFiles = ["cli.js", "index.js"];
+            const result = changes.filterSteps(steps, changedFiles);
+
+            expect(result).toEqual(steps);
+        });
+
+        it("should filter out steps that do not match the changeset triggers", () => {
+            const changes = require("../changes");
+            const steps = [
+                {
+                    when: {
+                        changeset: ["*.md"]
+                    }
+                },
+                {}
+            ];
+            const changedFiles = ["cli.js", "index.js"];
+            const result = changes.filterSteps(steps, changedFiles);
+
+            expect(result).toEqual([steps[1]]);
+        });
+    });
 });

--- a/__tests__/changes.test.js
+++ b/__tests__/changes.test.js
@@ -1,3 +1,5 @@
+const configFixtures = require("../__fixtures__/config");
+
 describe("changes", () => {
     describe("hasChangesetTrigger", () => {
         it("should return false if changeset param is null", () => {
@@ -179,6 +181,78 @@ describe("changes", () => {
             const result = changes.filterSteps(steps, changedFiles);
 
             expect(result).toEqual([steps[1]]);
+        });
+    });
+
+    describe("getMatchingConfig", () => {
+        it("should return config with no changes if no changeset triggers are present", () => {
+            const changes = require("../changes");
+            const config = configFixtures.noChangesetConfig;
+            const changedFiles = ["index.js", "package.json"];
+            const event = "push";
+
+            const result = changes.getMatchingConfig({
+                parsedConfig: config,
+                changedFiles,
+                droneEvent: event
+            });
+            expect(result).toMatchSnapshot();
+        });
+
+        it("should return config with no changes if event trigger does not match the drone event", () => {
+            const changes = require("../changes");
+            const config = configFixtures.noChangesetConfig;
+            const changedFiles = ["index.js", "package.json"];
+            const event = "pull_request";
+
+            const result = changes.getMatchingConfig({
+                parsedConfig: config,
+                changedFiles,
+                droneEvent: event
+            });
+            expect(result).toMatchSnapshot();
+        });
+
+        it("should disable pipeline which changeset trigger does not match changed files", () => {
+            const changes = require("../changes");
+            const config = configFixtures.getPipelineChangesetConfig(["*.js"]);
+            const changedFiles = ["README.md", "package.json"];
+            const event = "push";
+
+            const result = changes.getMatchingConfig({
+                parsedConfig: config,
+                changedFiles,
+                droneEvent: event
+            });
+            expect(result).toMatchSnapshot();
+        });
+
+        it("should filter out steps which changeset trigger does not match the changes", () => {
+            const changes = require("../changes");
+            const config = configFixtures.stepsChangesetConfig;
+            const changedFiles = ["index.js", "package.json"];
+            const event = "push";
+
+            const result = changes.getMatchingConfig({
+                parsedConfig: config,
+                changedFiles,
+                droneEvent: event
+            });
+            expect(result).toMatchSnapshot();
+        });
+
+        it("should replace pipelines where all steps are filtered out with noop config", () => {
+            const changes = require("../changes");
+            const config = configFixtures.getConfigWithStepsChangeset(["*.md"]);
+            const changedFiles = ["index.js", "package.json"];
+            const event = "push";
+
+            const result = changes.getMatchingConfig({
+                parsedConfig: config,
+                changedFiles,
+                droneEvent: event
+            });
+            expect(result).toMatchSnapshot();
         });
     });
 });

--- a/__tests__/changes.test.js
+++ b/__tests__/changes.test.js
@@ -107,4 +107,51 @@ describe("changes", () => {
             expect(result).toBe(true);
         });
     });
+
+    describe("matchChanges", () => {
+        it("should return false if neither include nor exclude filters are set", () => {
+            const changes = require("../changes");
+            const changedFiles = ["package.json", "index.js"];
+            const trigger = {};
+            const result = changes.matchChanges(trigger, changedFiles);
+
+            expect(result).toBe(false);
+        });
+
+        it("should return false if changed files do not match the include trigger", () => {
+            const changes = require("../changes");
+            const changedFiles = ["package.json", "index.js"];
+            const trigger = {include: ["*.md"]};
+            const result = changes.matchChanges(trigger, changedFiles);
+
+            expect(result).toBe(false);
+        });
+
+        it("should return true if changed files match the include trigger", () => {
+            const changes = require("../changes");
+            const changedFiles = ["package.json", "index.js"];
+            const trigger = {include: ["*.js"]};
+            const result = changes.matchChanges(trigger, changedFiles);
+
+            expect(result).toBe(true);
+        });
+
+        it("should return false if changed files match the exclude trigger", () => {
+            const changes = require("../changes");
+            const changedFiles = ["cli.js", "index.js"];
+            const trigger = {exclude: ["*.js"]};
+            const result = changes.matchChanges(trigger, changedFiles);
+
+            expect(result).toBe(false);
+        });
+
+        it("should return true if changed files do not match the exclude trigger", () => {
+            const changes = require("../changes");
+            const changedFiles = ["cli.js", "index.js"];
+            const trigger = {exclude: ["*.md"]};
+            const result = changes.matchChanges(trigger, changedFiles);
+
+            expect(result).toBe(true);
+        });
+    });
 });

--- a/__tests__/changes.test.js
+++ b/__tests__/changes.test.js
@@ -1,0 +1,66 @@
+describe("changes", () => {
+    describe("hasChangesetTrigger", () => {
+        it("should return false if changeset param is null", () => {
+            const changes = require("../changes");
+            const result = changes.hasChangesetTrigger(null);
+
+            expect(result).toBe(false);
+        });
+
+        it("should return false if changeset param is an empty array", () => {
+            const changes = require("../changes");
+            const result = changes.hasChangesetTrigger([]);
+
+            expect(result).toBe(false);
+        });
+
+        it("should return true if changeset param is non-empty array", () => {
+            const changes = require("../changes");
+            const result = changes.hasChangesetTrigger([1]);
+
+            expect(result).toBe(true);
+        });
+
+        it("should return false if changeset param is an object with no 'include' or 'exclude' keys", () => {
+            const changes = require("../changes");
+            const result = changes.hasChangesetTrigger({});
+
+            expect(result).toBe(false);
+        });
+
+        it("should return false if changeset's 'include' value is empty", () => {
+            const changes = require("../changes");
+            const result = changes.hasChangesetTrigger({include: []});
+
+            expect(result).toBe(false);
+        });
+
+        it("should return false if changeset's 'exclude' value is empty", () => {
+            const changes = require("../changes");
+            const result = changes.hasChangesetTrigger({exclude: []});
+
+            expect(result).toBe(false);
+        });
+
+        it("should return true if changeset's 'include' value is non-empty", () => {
+            const changes = require("../changes");
+            const result = changes.hasChangesetTrigger({include: [1]});
+
+            expect(result).toBe(true);
+        });
+
+        it("should return true if changeset's 'exclude' value is non-empty", () => {
+            const changes = require("../changes");
+            const result = changes.hasChangesetTrigger({exclude: [1]});
+
+            expect(result).toBe(true);
+        });
+
+        it("should ignore 'exclude' value if 'include' is present", () => {
+            const changes = require("../changes");
+            const result = changes.hasChangesetTrigger({include: [], exclude: [1]});
+
+            expect(result).toBe(false);
+        });
+    });
+});

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -95,7 +95,7 @@ describe("index.handler", () => {
         expect(logMock).toBeCalledWith("No config found");
     });
 
-    it("should respond with rawConfig if config is valid", async () => {
+    it("should respond with filteredConfig if config is valid", async () => {
         const rawConfig = "123";
         mockSecrets({github: "123", plugin: "123"});
         mockOctokit();
@@ -120,7 +120,7 @@ describe("index.handler", () => {
         await index.handler(mockEvent, {}, callback);
         expect(callback).toBeCalledWith(null, {
             statusCode: 200,
-            body: rawConfig
+            body: JSON.stringify({Data: ""})
         });
     });
 });

--- a/changes.js
+++ b/changes.js
@@ -12,7 +12,8 @@ const hasChangesetTrigger = changeset => {
     if (!changeset) return false;
     if (Array.isArray(changeset)) return changeset.length > 0;
 
-    return changeset.include || changeset.exclude;
+    const changesetConfig = changeset.include || changeset.exclude || [];
+    return changesetConfig.length > 0;
 };
 
 const getIncludeTriggers = triggerConfig =>

--- a/changes.js
+++ b/changes.js
@@ -28,7 +28,7 @@ const isMatchingEvent = (eventTrigger, event) => {
 
 const matchChanges = (triggerConfig, changedFiles) => {
     const includeTriggers = getIncludeTriggers(triggerConfig);
-    if (includeTrigger) {
+    if (includeTriggers) {
         return mm(changedFiles, includeTriggers).length > 0;
     }
 

--- a/changes.js
+++ b/changes.js
@@ -42,7 +42,7 @@ const matchChanges = (triggerConfig, changedFiles) => {
 const filterSteps = (steps, changedFiles) =>
     steps.filter(step => {
         const trigger = step.when || {};
-        if (!hasChangesetTrigger(trigger)) return true;
+        if (!hasChangesetTrigger(trigger.changeset)) return true;
 
         return matchChanges(trigger.changeset, changedFiles);
     }, []);

--- a/changes.js
+++ b/changes.js
@@ -56,17 +56,16 @@ const getMatchingConfig = ({parsedConfig, changedFiles, droneEvent}) => {
             return yaml.stringify(configObj);
         }
 
-        if (!hasChangesetTrigger(trigger.changeset)) {
-            return yaml.stringify(configObj);
-        }
+        if (hasChangesetTrigger(trigger.changeset)) {
+            const hasMatchingChanges = matchChanges(
+                configObj.trigger.changeset,
+                changedFiles
+            );
 
-        const hasMatchingChanges = matchChanges(
-            configObj.trigger.changeset,
-            changedFiles
-        );
-        if (!hasMatchingChanges) {
-            configObj.trigger = {event: {exclude: ["*"]}};
-            return yaml.stringify(configObj);
+            if (!hasMatchingChanges) {
+                configObj.trigger = {event: {exclude: ["*"]}};
+                return yaml.stringify(configObj);
+            }
         }
 
         const matchingSteps = filterSteps(configObj.steps, changedFiles);

--- a/changes.js
+++ b/changes.js
@@ -8,15 +8,27 @@ const noopConfig = index => `kind: pipeline
       exclude: [ "*" ]
 `;
 
-const hasChangesetTrigger = changeset =>
-    changeset && (changeset.include || changeset.exclude);
+const hasChangesetTrigger = changeset => {
+    if (!changeset) return false;
+    if (Array.isArray(changeset)) return changeset.length > 0;
 
-const isMatchingEvent = (eventTrigger, event) =>
-    eventTrigger.include && eventTrigger.include.indexOf(event) > -1;
+    return changeset.include || changeset.exclude;
+};
+
+const getIncludeTriggers = triggerConfig =>
+    Array.isArray(triggerConfig) ? triggerConfig : triggerConfig.include;
+
+const isMatchingEvent = (eventTrigger, event) => {
+    const includeTriggers = getIncludeTriggers(eventTrigger);
+    if (!includeTriggers) return false;
+
+    return includeTriggers.indexOf(event) > -1;
+};
 
 const matchChanges = (triggerConfig, changedFiles) => {
-    if (triggerConfig.include) {
-        return mm(changedFiles, triggerConfig.include).length > 0;
+    const includeTriggers = getIncludeTriggers(triggerConfig);
+    if (includeTrigger) {
+        return mm(changedFiles, includeTriggers).length > 0;
     }
 
     if (triggerConfig.exclude) {
@@ -65,4 +77,11 @@ const getMatchingConfig = ({parsedConfig, changedFiles, droneEvent}) => {
     return filteredConfig.join("\n---\n");
 };
 
-module.exports = getMatchingConfig;
+module.exports = {
+    hasChangesetTrigger,
+    getIncludeTriggers,
+    isMatchingEvent,
+    matchChanges,
+    filterSteps,
+    getMatchingConfig
+};

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const Octokit = require("@octokit/rest");
 const logger = require("./log");
 const source = require("./source");
 const getSecrets = require("./env");
-const getMatchingConfig = require("./matchChanges");
+const changes = require("./changes");
 
 const respondSuccess = (callback, body) =>
     callback(null, {
@@ -68,7 +68,7 @@ module.exports.handler = async (event, context, callback) => {
 
     logger.log("Changed files", changedFiles);
 
-    const finalConfig = getMatchingConfig({
+    const finalConfig = changes.getMatchingConfig({
         parsedConfig,
         changedFiles,
         droneEvent: body.build.event

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+    parser: "babel",
+    trailingComma: "none",
+    useTabs: false,
+    tabWidth: 4,
+    semi: true,
+    bracketSpacing: false,
+    printWidth: 90,
+    overrides: [
+        {
+            files: "package.json",
+            options: {
+                tabWidth: 2,
+                parser: "json"
+            }
+        }
+    ]
+};


### PR DESCRIPTION
- [x] Support shorthand syntax for `include` triggers (both `event` and `changeset`)
```
event:
  - push
  - pull_request
```
- [x] Fix filtering steps (was using incorrect trigger config)
- [x] Fix filtering steps when pipeline does not have changeset trigger
- [x] Add tests for changes logic